### PR TITLE
Pb/fix 600 when saving a new module the mapping path is created incorrectly

### DIFF
--- a/www/backend/core/com/sysadmin.cfc
+++ b/www/backend/core/com/sysadmin.cfc
@@ -562,23 +562,6 @@ component displayname="sysadmin" output="false" {
 
         return local.qCustomMappings;
     }
-    
-    public query function getCustomMappingByModuleID(required numeric customMappingID){
-
-        local.qCustomMappings = queryExecute (
-            options = {datasource = application.datasource},
-            params = {
-                customMappingID: {type: "numeric", value: arguments.customMappingID}
-            },
-            sql = "
-                SELECT *
-                FROM custom_mappings
-                WHERE intModuleID = :customMappingID
-            "
-        );
-
-        return local.qCustomMappings;
-    }
 
     public query function getSystemMappings(){
 

--- a/www/backend/core/com/sysadmin.cfc
+++ b/www/backend/core/com/sysadmin.cfc
@@ -562,6 +562,23 @@ component displayname="sysadmin" output="false" {
 
         return local.qCustomMappings;
     }
+    
+    public query function getCustomMappingByModuleID(required numeric customMappingID){
+
+        local.qCustomMappings = queryExecute (
+            options = {datasource = application.datasource},
+            params = {
+                customMappingID: {type: "numeric", value: arguments.customMappingID}
+            },
+            sql = "
+                SELECT *
+                FROM custom_mappings
+                WHERE intModuleID = :customMappingID
+            "
+        );
+
+        return local.qCustomMappings;
+    }
 
     public query function getSystemMappings(){
 

--- a/www/backend/core/handler/sysadmin/modules.cfm
+++ b/www/backend/core/handler/sysadmin/modules.cfm
@@ -304,7 +304,7 @@ dump('Hello settings!');
             }
         }
 
-        // Create the file for the login inlude
+        // Create the file for the login include
         createLoginFileSuccess = true;
         if (!fileExists(expandPath('/backend/modules/#form.prefix#/login_include.cfm'))) {
 savecontent variable="loginContent" {
@@ -382,23 +382,28 @@ if (structKeyExists(url, "delete_module")) {
     if (isNumeric(url.delete_module)) {
 
         // Delete picture first
-        qPicture = queryExecute(
+        qModuleToDelete = queryExecute(
             options = {datasource = application.datasource},
             params = {
                 modulID: {type: "numeric", value: url.delete_module}
             },
             sql="
-                SELECT strPicture
+                SELECT strTabPrefix, strPicture
                 FROM modules
                 WHERE intModuleID = :modulID
             "
         )
 
-        if (qPicture.recordCount and len(trim(qPicture.strPicture))) {
+        if (qModuleToDelete.recordCount and len(trim(qModuleToDelete.strPicture))) {
 
             // Delete picture using a function
-            application.objGlobal.deleteFile(expandPath("/userdata/images/modules/#qPicture.strPicture#"));
+            application.objGlobal.deleteFile(expandPath("/userdata/images/modules/#qModuleToDelete.strPicture#"));
 
+        }
+
+        //Delete all folders and Files related to this module
+        if (directoryExists(expandPath('/backend/modules/#qModuleToDelete.strTabPrefix#'))) {
+            directoryDelete(expandPath('/backend/modules/#qModuleToDelete.strTabPrefix#'), true);
         }
 
         queryExecute(

--- a/www/backend/core/handler/sysadmin/modules.cfm
+++ b/www/backend/core/handler/sysadmin/modules.cfm
@@ -149,7 +149,7 @@ if (structKeyExists(form, "edit_module")) {
         param name="form.path" default="";
         param name="form.redirect" default="";
 
-        mapping = "backend/modules/" & form.prefix & "/settings";
+        mapping = "modules/" & form.prefix & "/settings";
         path =  "backend/modules/" & form.prefix & "/settings.cfm";
 
         // Is there already an entry in the custom mappings?

--- a/www/backend/core/views/sysadmin/module_details.cfm
+++ b/www/backend/core/views/sysadmin/module_details.cfm
@@ -3,7 +3,6 @@
 
     allowedFileTypesList = fileList.allowedFileTypesList;
     acceptFileTypesList = fileList.acceptFileTypesList;
-    dump(qModule);
 </cfscript>
 <cfoutput>
 <form id="submit_form" method="post" action="#application.mainURL#/sysadm/modules" enctype="multipart/form-data">

--- a/www/backend/core/views/sysadmin/module_details.cfm
+++ b/www/backend/core/views/sysadmin/module_details.cfm
@@ -7,7 +7,11 @@
 </cfscript>
 <cfoutput>
 <form id="submit_form" method="post" action="#application.mainURL#/sysadm/modules" enctype="multipart/form-data">
-<input type="hidden" name="edit_module" value="#qModule.intModuleID#">
+    <input type="hidden" name="edit_module" value="#qModule.intModuleID#">
+    <!--- to not send empty and therefore deleting the prefix if field is disabled  --->
+    <cfif len(trim(qModule.strSettingPath))>
+        <input type="hidden" name="prefix" value="#qModule.strTabPrefix#">
+    </cfif>
     <div class="card-body">
         <div class="row">
             <div class="col-lg-6">

--- a/www/backend/core/views/sysadmin/module_details.cfm
+++ b/www/backend/core/views/sysadmin/module_details.cfm
@@ -59,7 +59,7 @@
                         </div>
                         <cfif len(trim(qModule.strSettingPath))>
                             Develop your module in: /backend/modules/#qModule.strTabPrefix#/<br />
-                            Settings file: /#qModule.strSettingPath#.cfm<br />
+                            Settings file: /backend/#qModule.strSettingPath#.cfm<br />
                             Mapping: <a href="#application.mainURL#/modules/#qModule.strTabPrefix#/settings" target="_blank">#application.mainURL#/modules/#qModule.strTabPrefix#/settings</a>
                         </cfif>
                     </fieldset>

--- a/www/backend/core/views/sysadmin/module_details.cfm
+++ b/www/backend/core/views/sysadmin/module_details.cfm
@@ -27,7 +27,7 @@
                 <div class="mb-3">
                     <label class="form-label">Module name *</label>
                     <div class="input-group input-group-flat">
-                        <input type="text" class="form-control" name="module_name" autocomplete="off" maxlength="50" value="#HTMLEditFormat(qModule.strModuleName)#" required <cfif structKeyExists(variables, "blockRename")>#blockRename#</cfif>>
+                        <input type="text" class="form-control" name="module_name" autocomplete="off" maxlength="50" value="#HTMLEditFormat(qModule.strModuleName)#" required <cfif structKeyExists(variables, "blockRename")>#blockRename# title="You cant change the name after creation. Create a new module instead."</cfif>>
                         <span class="input-group-text">
                             <a href="##?" class="input-group-link" data-bs-toggle="modal" data-bs-target="##module_name_#qModule.intModuleID#"><i class="fas fa-globe" data-bs-toggle="tooltip" data-bs-placement="top" title="Translate module name"></i></a>
                         </span>
@@ -48,7 +48,7 @@
                         <div class="mb-3">
                             <small class="form-hint mb-3">The folder and files will be created after saving. The <i>navigation.cfm</i> file will help build the navigation.</small>
                             <label class="mb-1">Folder and table prefix *</label>
-                            <input type="text" class="form-control" name="prefix" placeholder="prefix" autocomplete="off" maxlength="20" value="#HTMLEditFormat(qModule.strTabPrefix)#" required <cfif structKeyExists(variables, "blockRename")>#blockRename#</cfif>>
+                            <input type="text" class="form-control" name="prefix" placeholder="prefix" autocomplete="off" maxlength="20" value="#HTMLEditFormat(qModule.strTabPrefix)#" required <cfif structKeyExists(variables, "blockRename")>#blockRename# title="You cant change the path after creation. Create a new module instead."</cfif>>
                             <small class="form-hint">
                                 Use the <b>same prefix</b> for your database tables and folder name.
                             </small>
@@ -56,7 +56,7 @@
                         <cfif len(trim(qModule.strSettingPath))>
                             Develop your module in: /backend/modules/#qModule.strTabPrefix#/<br />
                             Settings file: /#qModule.strSettingPath#.cfm<br />
-                            Mapping: <a href="#application.mainURL#/backend/modules/#qModule.strTabPrefix#/settings" target="_blank">#application.mainURL#/backend/modules/#qModule.strTabPrefix#/settings</a>
+                            Mapping: <a href="#application.mainURL#/modules/#qModule.strTabPrefix#/settings" target="_blank">#application.mainURL#/modules/#qModule.strTabPrefix#/settings</a>
                         </cfif>
                     </fieldset>
                 </div>

--- a/www/backend/core/views/sysadmin/module_details.cfm
+++ b/www/backend/core/views/sysadmin/module_details.cfm
@@ -3,6 +3,7 @@
 
     allowedFileTypesList = fileList.allowedFileTypesList;
     acceptFileTypesList = fileList.acceptFileTypesList;
+    dump(qModule);
 </cfscript>
 <cfoutput>
 <form id="submit_form" method="post" action="#application.mainURL#/sysadm/modules" enctype="multipart/form-data">
@@ -27,7 +28,7 @@
                 <div class="mb-3">
                     <label class="form-label">Module name *</label>
                     <div class="input-group input-group-flat">
-                        <input type="text" class="form-control" name="module_name" autocomplete="off" maxlength="50" value="#HTMLEditFormat(qModule.strModuleName)#" required <cfif structKeyExists(variables, "blockRename")>#blockRename# title="You cant change the name after creation. Create a new module instead."</cfif>>
+                        <input type="text" class="form-control" name="module_name" autocomplete="off" maxlength="50" value="#HTMLEditFormat(qModule.strModuleName)#" required>
                         <span class="input-group-text">
                             <a href="##?" class="input-group-link" data-bs-toggle="modal" data-bs-target="##module_name_#qModule.intModuleID#"><i class="fas fa-globe" data-bs-toggle="tooltip" data-bs-placement="top" title="Translate module name"></i></a>
                         </span>
@@ -48,7 +49,7 @@
                         <div class="mb-3">
                             <small class="form-hint mb-3">The folder and files will be created after saving. The <i>navigation.cfm</i> file will help build the navigation.</small>
                             <label class="mb-1">Folder and table prefix *</label>
-                            <input type="text" class="form-control" name="prefix" placeholder="prefix" autocomplete="off" maxlength="20" value="#HTMLEditFormat(qModule.strTabPrefix)#" required <cfif structKeyExists(variables, "blockRename")>#blockRename# title="You cant change the path after creation. Create a new module instead."</cfif>>
+                            <input type="text" class="form-control" name="prefix" placeholder="prefix" autocomplete="off" maxlength="20" value="#HTMLEditFormat(qModule.strTabPrefix)#" required <cfif len(trim(qModule.strSettingPath))>disabled style="cursor: not-allowed;" data-bs-toggle="tooltip" title="You cant change the path after creation. Create a new module instead."</cfif>>
                             <small class="form-hint">
                                 Use the <b>same prefix</b> for your database tables and folder name.
                             </small>

--- a/www/backend/core/views/sysadmin/module_details.cfm
+++ b/www/backend/core/views/sysadmin/module_details.cfm
@@ -27,7 +27,7 @@
                 <div class="mb-3">
                     <label class="form-label">Module name *</label>
                     <div class="input-group input-group-flat">
-                        <input type="text" class="form-control" name="module_name" autocomplete="off" maxlength="50" value="#HTMLEditFormat(qModule.strModuleName)#" required>
+                        <input type="text" class="form-control" name="module_name" autocomplete="off" maxlength="50" value="#HTMLEditFormat(qModule.strModuleName)#" required <cfif structKeyExists(variables, "blockRename")>#blockRename#</cfif>>
                         <span class="input-group-text">
                             <a href="##?" class="input-group-link" data-bs-toggle="modal" data-bs-target="##module_name_#qModule.intModuleID#"><i class="fas fa-globe" data-bs-toggle="tooltip" data-bs-placement="top" title="Translate module name"></i></a>
                         </span>
@@ -48,7 +48,7 @@
                         <div class="mb-3">
                             <small class="form-hint mb-3">The folder and files will be created after saving. The <i>navigation.cfm</i> file will help build the navigation.</small>
                             <label class="mb-1">Folder and table prefix *</label>
-                            <input type="text" class="form-control" name="prefix" placeholder="prefix" autocomplete="off" maxlength="20" value="#HTMLEditFormat(qModule.strTabPrefix)#" required>
+                            <input type="text" class="form-control" name="prefix" placeholder="prefix" autocomplete="off" maxlength="20" value="#HTMLEditFormat(qModule.strTabPrefix)#" required <cfif structKeyExists(variables, "blockRename")>#blockRename#</cfif>>
                             <small class="form-hint">
                                 Use the <b>same prefix</b> for your database tables and folder name.
                             </small>

--- a/www/backend/core/views/sysadmin/module_edit.cfm
+++ b/www/backend/core/views/sysadmin/module_edit.cfm
@@ -10,7 +10,7 @@
     }
 
     qModule = objSysadmin.getModule(thisModuleID);
-   
+
     if(not qModule.recordCount){
         location url="#application.mainURL#/sysadmin/modules" addtoken="false";
     }
@@ -36,8 +36,8 @@
     //Disable renaming of the module after path creations. 
     //This way Module files are not doubled. 
     //User needs to create a new Module if he wants to change the path/name.
-    qCustomMappingByModuleID = objSysadmin.getCustomMappingByModuleID(thisModuleID);
-    if(len(trim(qCustomMappingByModuleID.strPath))){
+    qCustomMappingByModuleID = objSysadmin.getModule(thisModuleID);
+    if(len(trim(qCustomMappingByModuleID.strSettingPath))){
         blockRename = "readonly";
     } 
 

--- a/www/backend/core/views/sysadmin/module_edit.cfm
+++ b/www/backend/core/views/sysadmin/module_edit.cfm
@@ -33,14 +33,6 @@
     
     getModal = new backend.core.com.translate();
 
-    //Disable renaming of the module after path creations. 
-    //This way Module files are not doubled. 
-    //User needs to create a new Module if he wants to change the path/name.
-    qCustomMappingByModuleID = objSysadmin.getModule(thisModuleID);
-    if(len(trim(qCustomMappingByModuleID.strSettingPath))){
-        blockRename = "readonly";
-    } 
-
 </cfscript>
 
 

--- a/www/backend/core/views/sysadmin/module_edit.cfm
+++ b/www/backend/core/views/sysadmin/module_edit.cfm
@@ -10,7 +10,7 @@
     }
 
     qModule = objSysadmin.getModule(thisModuleID);
-
+   
     if(not qModule.recordCount){
         location url="#application.mainURL#/sysadmin/modules" addtoken="false";
     }
@@ -30,8 +30,16 @@
             scheduletasks = "show active";
             break;
     }
-
+    
     getModal = new backend.core.com.translate();
+
+    //Disable renaming of the module after path creations. 
+    //This way Module files are not doubled. 
+    //User needs to create a new Module if he wants to change the path/name.
+    qCustomMappingByModuleID = objSysadmin.getCustomMappingByModuleID(thisModuleID);
+    if(len(trim(qCustomMappingByModuleID.strPath))){
+        blockRename = "readonly";
+    } 
 
 </cfscript>
 


### PR DESCRIPTION
The "backend" is removed from sef url creation.
Whilst doing the task we discovered if you change name or path of a module the files get newly created, so we disabled(readonly) the renaming and repathing of a module.
Closes #600