### PR TITLE
fix: no strings allowed anymore

### DIFF
--- a/www/backend/core/views/sysadmin/plan_details.cfm
+++ b/www/backend/core/views/sysadmin/plan_details.cfm
@@ -86,7 +86,7 @@
             <div class="row mb-3">
                 <div class="col-lg-4">
                     <label class="form-label text-end">Maximum users *</label>
-                    <input type="text" class="form-control text-end" name="max_users" autocomplete="off" maxlength="10" value="#qPlan.intMaxUsers#" placeholder="0" required>
+                    <input type="number" class="form-control text-end" name="max_users" autocomplete="off" maxlength="10" value="#qPlan.intMaxUsers#" placeholder="0" required>
                     <small class="form-hint">
                         Enter 0 if you don't want to use the user limit.
                     </small>
@@ -94,9 +94,9 @@
                 <div class="col-lg-4">
                     <label class="form-label text-end">Number of test days *</label>
                     <cfif qPlan.blnFree>
-                        <input type="text" class="form-control text-end" value="#qPlan.intNumTestDays#" disabled style="cursor: not-allowed;" data-bs-toggle="tooltip" data-bs-placement="top" title="Its a free plan">
+                        <input type="number" class="form-control text-end" value="#qPlan.intNumTestDays#" disabled style="cursor: not-allowed;" data-bs-toggle="tooltip" data-bs-placement="top" title="Its a free plan">
                     <cfelse>
-                        <input type="text" class="form-control text-end" name="test_days" autocomplete="off" maxlength="10" value="#qPlan.intNumTestDays#" placeholder="30" required>
+                        <input type="number" class="form-control text-end" name="test_days" autocomplete="off" maxlength="10" value="#qPlan.intNumTestDays#" placeholder="30" required>
                     </cfif>
                     <small class="form-hint">
                         Enter 0 if you don't want to provide any test days.

--- a/www/backend/core/views/sysadmin/plan_prices.cfm
+++ b/www/backend/core/views/sysadmin/plan_prices.cfm
@@ -40,7 +40,7 @@
                 <div class="col-lg-3 me-3 mb-3">
                     <div class="mb-3 text-end w-75">
                         <label class="form-label text-end">Vat (%)</label>
-                        <input type="text" name="vat" class="form-control text-end" autocomplete="off" value="#trim(decimalFormat(qPrices.decVat))#" maxlength="10">
+                        <input type="number" name="vat" class="form-control text-end" autocomplete="off" value="#trim(decimalFormat(qPrices.decVat))#" maxlength="10">
                     </div>
                 </div>
                 <div class="col-lg-6">


### PR DESCRIPTION
Since input type number is working in edge again, i added the type to the problematic fields
Closes #467