### PR TITLE
add: Undo cancellation dropdown on canceled invoices

### DIFF
--- a/www/backend/core/views/sysadmin/invoices.cfm
+++ b/www/backend/core/views/sysadmin/invoices.cfm
@@ -234,6 +234,9 @@
                                                             <cfif qInvoices.intPaymentStatusID eq 1 or qInvoices.intPaymentStatusID eq 2>
                                                                 <a class="dropdown-item cursor-pointer" href="#application.mainURL#/sysadm/invoices?i=#qInvoices.intInvoiceID#&status=5&redirect=#urlEncodedFormat('sysadmin/invoices?del_redirect')#">Cancel invoice</a>
                                                             </cfif>
+                                                            <cfif qInvoices.intPaymentStatusID eq 5>
+                                                                <a class="dropdown-item" href="#application.mainURL#/sysadm/invoices?i=#qInvoices.intInvoiceID#&open&redirect=#urlEncodedFormat('sysadmin/invoices?del_redirect')#">Undo cancellation</a>
+                                                            </cfif>
                                                             <a class="dropdown-item cursor-pointer" onclick="sweetAlert('warning', '#application.mainURL#/sysadm/invoices?i=#qInvoices.intInvoiceID#&status=delete&redirect=#urlEncodedFormat('sysadmin/invoices?del_redirect')#', 'Delete invoice', 'Do you want to delete this invoice permanently?', 'No, cancel!', 'Yes, delete!')">Delete invoice</a>
                                                         </div>
                                                     </div>


### PR DESCRIPTION
Added undo cancelation to action dropdown.
I used open method which appends the new status depending on payment.

->Undo opens the reopened invoice now and sets the new status
closes #373 