### PR TITLE
Refresh language cache after translation updates

### DIFF
--- a/www/backend/core/handler/sysadmin/translations.cfm
+++ b/www/backend/core/handler/sysadmin/translations.cfm
@@ -53,7 +53,7 @@ if (structKeyExists(form, "new_variable")) {
 
     getAlert('Variable added successfully.', 'success');
     session.search = form.variable;
-    location url="#application.mainURL#/sysadmin/translations" addtoken="false";
+    location url="#application.mainURL#/sysadmin/translations?reinit=3" addtoken="false";
 
 }
 
@@ -74,7 +74,7 @@ if (structKeyExists(url, "delete_trans")) {
 
         getAlert('Translation deleted', 'success');
         structDelete(session, "search");
-        location url="#application.mainURL#/sysadmin/translations" addtoken="false";
+        location url="#application.mainURL#/sysadmin/translations?reinit=3" addtoken="false";
 
     }
 
@@ -101,7 +101,7 @@ if (structKeyExists(form, "edit_variable")) {
         }
 
         getAlert('Translation saved!', 'success');
-        location url="#application.mainURL#/sysadmin/translations" addtoken="false";
+        location url="#application.mainURL#/sysadmin/translations?reinit=3" addtoken="false";
     }
 
 }
@@ -126,7 +126,7 @@ if (structKeyExists(form, "edit_syst_variable")) {
         }
 
         getAlert('Translation saved!', 'success');
-        location url="#application.mainURL#/sysadmin/translations?tr=system" addtoken="false";
+        location url="#application.mainURL#/sysadmin/translations?tr=system&reinit=3" addtoken="false";
     }
 
 }
@@ -233,7 +233,7 @@ if (structKeyExists(form, "bulk_translate")) {
 
 
         getAlert('The translation finished successfully!');
-        location url="#application.mainURL#/sysadmin/translations?tr=bulk" addtoken="false";
+        location url="#application.mainURL#/sysadmin/translations?tr=bulk&reinit=3" addtoken="false";
 
         // Translate custom translations if selected
         /*


### PR DESCRIPTION
## Problem

Translation changes are persisted to the database, but Saaster continues using the cached `application.langStruct` until a sysadmin manually invokes `?reinit=3`.

## Solution

Successful translation mutations now include the existing language-cache refresh in their redirect.

Covered paths:

- add custom translation
- delete custom translation
- edit custom translation
- edit system translation
- bulk translation

The existing redirect context is preserved for system and bulk translation views.

## Scope

- No schema changes
- No API changes
- No authorization changes
- No dependency changes
- No changes to `Application.cfc`
- No redesign of the existing cache mechanism

## Validation

- Add custom translation: PASS
- Edit custom translation: PASS
- Delete custom translation: PASS
- System translation: PASS
- Duplicate/failure behaviour: PASS
- Unauthorized translation access: PASS
- Unauthorized direct `?reinit=3`: PASS
- Immediate `application.langStruct` refresh: PASS
- Development Compose validation: PASS
- Production Compose validation: PASS
- `git diff --check`: PASS

Bulk translation success was not runtime-tested because no non-production DeepL API key was available. Its redirect path was reviewed, and the DeepL failure path was runtime-tested.

Fixes #702
